### PR TITLE
ExpDate.MMYY property returns '%m%y', without separator character

### DIFF
--- a/pycard/card.py
+++ b/pycard/card.py
@@ -221,6 +221,13 @@ class ExpDate(object):
         return self.expired_after.strftime('%m/%y')
 
     @property
+    def MMYY(self):
+        """
+        Returns the expiration date in MMYY format
+        """
+        return self.expired_after.strftime('%m%y')
+
+    @property
     def mm(self):
         """
         Returns the expiration date in MM format.


### PR DESCRIPTION
Hi,
I added missing (for  me) method. Merge it if you don't mind :)